### PR TITLE
Refactor README.md for clarity and organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,148 +2,95 @@
 
 This is a simple Sinatra project set up for Test-Driven Development using RSpec.
 
-## Ruby Version
+## Project Overview
 
-- Ruby 3.1.2 (Managed by `.ruby-version` and `.tool-versions`)
+This Sinatra web application guides users through a three-step image processing workflow:
 
-## Setup
+1.  **Upload and Recolor**: Users upload a PNG image, which is then processed to apply an "impressionist" blob recoloring effect.
+2.  **Extract Blob Graph**: A blob-adjacency graph is extracted from the recolored image and rendered as an SVG.
+3.  **Smooth and Validate Graph**: The graph is smoothed and validated to ensure it forms a quilt-legal planar graph, with the final result also rendered as an SVG.
+
+At each step, users can view the intermediate visual result and adjust processing options before continuing to the next stage.
+
+The core application logic is found in `app.rb`. During processing, intermediate files (images, label data, SVGs) are stored in per-session subfolders within a `tmp/` directory.
+
+## Getting Started
+
+### Ruby Version
+
+- Ruby 3.1.2 (This version is managed by `.ruby-version` and `.tool-versions` files in the repository).
+
+### Setup
 
 1.  **Install Ruby:**
-    Make sure you have Ruby 3.1.2 installed. You can use a version manager like RVM or asdf:
-    - RVM: `rvm install 3.1.2 && rvm use 3.1.2`
-    - asdf: `asdf install ruby 3.1.2 && asdf global ruby 3.1.2`
+    Ensure Ruby 3.1.2 is installed. You can use a version manager like RVM or asdf:
+    - RVM:
+      ```bash
+      rvm install 3.1.2 && rvm use 3.1.2
+      ```
+    - asdf:
+      ```bash
+      asdf install ruby 3.1.2 && asdf global ruby 3.1.2
+      ```
 
 2.  **Install Bundler:**
-    If you don't have Bundler installed:
-    `gem install bundler`
+    If Bundler is not already installed:
+    ```bash
+    gem install bundler
+    ```
 
 3.  **Install Dependencies:**
     Navigate to the project directory and run:
-    `bundle install`
+    ```bash
+    bundle install
+    ```
 
-## Running Tests
+### Running Tests
 
-### RSpec
+#### RSpec
 To run all tests:
-`bundle exec rspec`
+```bash
+bundle exec rspec
+```
+Alternatively, using Rake:
+```bash
+bundle exec rake
+```
 
-Or using Rake:
-`bundle exec rake`
-
-### Guard
+#### Guard
 To automatically run tests when files change:
-`bundle exec guard`
-
-## Application
-The main application file is `app.rb`.
-
-The Sinatra web application guides the user through the following process:
-1.  **Upload PNG and Recolor**: Upload a PNG image and apply “impressionist” blob recoloring using the `Impressionist` library.
-2.  **Extract Blob Graph**: Extract a blob-adjacency graph from the labeled image using the `BlobGraph` library and render it as an SVG.
-3.  **Smooth and Validate Graph**: Smooth and validate the graph into a quilt-legal planar graph using the `QuiltGraph` library and render the final SVG.
-
-At each step, the user can see the intermediate result and adjust options before proceeding to the next stage.
-
-The application uses a `tmp/` directory to store per-session subfolders. These subfolders contain intermediate files generated during the process, such as images, label data, and SVGs.
-
-### Image Processing Library: Impressionist
-# lib/impressionist.rb
-#
-# A pure-Ruby library for “impressionist” blob detection and recoloring of PNG images,
-# now with enhanced control over blob size and noise.
-#
-# Features:
-#   • Optional box-blur to reduce noise.
-#   • Fixed-interval color quantization.
-#   • Two-pass connected-component labeling (4- or 8-connectivity).
-#   • Optional filtering of small blobs (min_blob_size).
-#   • Computes average RGB per blob and recolors entire blob to its average hue.
-#   • Clean API: load, process, and save.
-#
-# Dependencies:
-#   gem install chunky_png
-#
-# Usage Example:
-```ruby
-#   require_relative 'lib/impressionist'
-#
-#   options = {
-#     quant_interval: 16,
-#     blur:           true,
-#     blur_radius:    1,
-#     connectivity:   4,
-#     min_blob_size:  50
-#   }
-#
-#   # Recolor input.png → output.png
-#   Impressionist.recolor('input.png', 'output.png', options)
-#
-#   # Or get a Hash {image:, labels:, blob_count:} back instead of saving directly:
-#   result = Impressionist.process('input.png', options)
-#   result[:image].save('out.png')
+```bash
+bundle exec guard
 ```
 
-### Graph Extraction Library: BlobGraph
-# lib/blob_graph.rb
-#
-# A pure-Ruby library for extracting a blob-adjacency graph from a labeled image,
-# designed to integrate smoothly with the Sinatra quilting app and avoid redundant work.
-#
-# Assumptions:
-#  • You have already run a connected-component labeling (from Impressionist) to get a 2D labels array.
-#  • labels[y][x] is an integer blob ID (1..N) or 0 for background.
-#
-# Features:
-#   2.1 Detect junction pixels (where ≥3 blobs meet) and cluster them into junction centroids.
-#   2.2 Build adjacency lists and border-pixel sets for each pair of adjacent blobs.
-#   2.3 Map each border to its touching junctions to create straight-line edges (j1→j2).
-#   2.4 Optionally run Zhang-Suen thinning on each border, extract shortest path between junctions,
-#       and simplify via Ramer–Douglas–Peucker.
-#
-# Public API:
-#   BlobGraph.extract_from_labels(labels, options) ⇒ { vertices:, edges:, detailed_edges: }
-#
-#   • labels:  2D Array [height][width] of integer blob IDs (0 = background).
-#   • options: Hash (all optional):
-#       :junction_conn   (4 or 8; default: 8)  # connectivity when clustering junction pixels
-#       :path_conn       (4 or 8; default: 8)  # connectivity when BFS on skeleton
-#       :skeletonize     (Boolean; default: true)
-#       :simplify_tol    (Float; default: 2.0)  # tolerance for RDP simplification
-#
-# Returns:
-#   {
-#     vertices:       { j_id => [cx, cy], ... },
-#     edges:          [ [j1, j2], ... ],               # straight-line connectivity
-#     detailed_edges: [ { endpoints: [j1, j2], polyline: [[x,y],...] }, ... ]
-#   }
-#
-# Dependencies: None beyond Ruby stdlib.
-#
-# Example Usage:
-```ruby
-#   require_relative 'lib/blob_graph'
-#
-#   # Suppose `labels` is produced by Impressionist.connected_components
-#   result = BlobGraph.extract_from_labels(labels, {
-#     junction_conn: 8,
-#     path_conn:     8,
-#     skeletonize:   true,
-#     simplify_tol:  2.0
-#   })
-#
-#   vertices       = result[:vertices]        # { j_id => [cx,cy], ... }
-#   edges          = result[:edges]           # [ [j1,j2], ... ]
-#   detailed_edges = result[:detailed_edges]  # [ { endpoints:[j1,j2], polyline:[[x,y],...] }, ... ]
-```
+## Libraries
 
-### Quilt Graph Library: QuiltGraph
-# lib/quilt_graph.rb
-#
-# Module containing all graph logic for parsing an SVG into a quilt-graph,
-# correcting it into a viable quilt diagram, and exporting back to SVG.
-#
-# Since the Sinatra app already has a planar graph (vertices & edges),
-# we only need correct_quilt and graph_to_svg_string here.
-#
-# Dependencies: None beyond Ruby stdlib.
-#
+### Impressionist
+
+A pure-Ruby library for "impressionist" blob detection and recoloring of PNG images. It offers features such as:
+- Noise reduction (optional box-blur).
+- Fixed-interval color quantization.
+- Two-pass connected-component labeling (4- or 8-connectivity).
+- Optional filtering of small blobs.
+- Calculation of average RGB per blob and recoloring of the entire blob to its average hue.
+
+For more details, see `lib/impressionist.rb`.
+
+### BlobGraph
+
+A pure-Ruby library for extracting a blob-adjacency graph from a labeled image. Its key functions include:
+- Detecting junction pixels (where three or more blobs meet) and clustering them into centroids.
+- Building adjacency lists and border-pixel sets for each pair of adjacent blobs.
+- Mapping each border to its touching junctions to create straight-line graph edges.
+- Optionally, thinning borders (Zhang-Suen) and simplifying paths (Ramer–Douglas–Peucker).
+
+For more details, see `lib/blob_graph.rb`.
+
+### QuiltGraph
+
+A Ruby module providing graph logic to:
+- Parse an SVG into a quilt-graph structure.
+- Correct the graph into a viable quilt diagram.
+- Export the corrected graph back to an SVG format.
+
+For more details, see `lib/quilt_graph.rb`.


### PR DESCRIPTION
This commit significantly restructures and cleans up the README.md file.

Key changes include:
- Reorganized content into logical sections: "Project Overview", "Getting Started", and "Libraries".
- Moved detailed library descriptions from the README to the respective library source files, with brief summaries and links remaining in the README.
- Improved formatting for better readability, including consistent headings, lists, and code block styling.
- Enhanced clarity and conciseness of the text, particularly in the "Project Overview" to describe the application workflow.
- Removed redundant information and ensured language is user-friendly.