### PR TITLE
feat: Implement drag-and-drop palette extraction tool

### DIFF
--- a/lib/impressionist.rb
+++ b/lib/impressionist.rb
@@ -162,7 +162,7 @@ def process_image(img, options = {})
 
   output_image = _build_recolored_image(width, height, labels, avg_colors_map)
 
-  { image: output_image, labels: labels, blob_count: blob_count }
+  { image: output_image, labels: labels, blob_count: blob_count, avg_colors: avg_colors_map }
 end
 
     def merge_small_blobs(labels, quantized, width, height, small_blobs, connectivity)


### PR DESCRIPTION
This commit introduces a new feature allowing you to drag and drop an image onto a designated area on the main page. The backend then processes this image to extract dominant color swatches, focusing on larger color blobs and reducing noise.

Key changes include:

- A new POST route `/palette_upload` in `app.rb` to handle image uploads.
- Image processing logic using `Impressionist` to identify and extract average colors from significant blobs. Options for quantization, blur, and minimum blob size have been tuned for better results.
- Integration of `PaletteManager` to store the extracted `ChunkyPNG::Color` objects (though not persisted across requests in this iteration).
- Frontend enhancements in the `GET /` route:
    - A new HTML section for the palette tool with a drag-and-drop zone and an area for displaying color swatches.
    - Client-side JavaScript to manage file drag-and-drop, image upload via Fetch API, and dynamic rendering of the extracted color swatches.
- Integration tests for the `/palette_upload` route, covering successful uploads and error scenarios (no file, invalid file type).

The tool provides visual feedback during processing and displays the extracted color swatches directly on the page.