### PR TITLE
Fix color hex conversion and fixture paths

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -165,9 +165,9 @@ post '/palette_upload' do
     blob_sizes_map = impressionist_result[:blob_sizes] # 1-indexed
     blob_count = impressionist_result[:blob_count]
 
-    MAX_PALETTE_SIZE = 10
-    COLOR_SIMILARITY_THRESHOLD = 50 # Max RGB distance to be considered "different"
-    MIN_CANDIDATE_BLOB_SIZE = 10    # Absolute minimum size for a blob to be considered
+    max_palette_size = 10
+    color_similarity_threshold = 50 # Max RGB distance to be considered "different"
+    min_candidate_blob_size = 10    # Absolute minimum size for a blob to be considered
 
     candidates = []
     if raw_avg_colors && blob_sizes_map && blob_count > 0
@@ -182,7 +182,7 @@ post '/palette_upload' do
     end
 
     # Filter out initial tiny noise
-    candidates.reject! { |c| c[:size] < MIN_CANDIDATE_BLOB_SIZE }
+    candidates.reject! { |c| c[:size] < min_candidate_blob_size }
 
     # Sort candidates: primarily by size (descending)
     candidates.sort_by! { |c| -c[:size] }
@@ -191,18 +191,18 @@ post '/palette_upload' do
     final_palette_chunky_colors = []
     candidates.each do |candidate|
       is_too_similar = final_palette_chunky_colors.any? do |existing_color|
-        rgb_distance(candidate[:color], existing_color) < COLOR_SIMILARITY_THRESHOLD
+        rgb_distance(candidate[:color], existing_color) < color_similarity_threshold
       end
 
       unless is_too_similar
         final_palette_chunky_colors << candidate[:color]
       end
-      break if final_palette_chunky_colors.length >= MAX_PALETTE_SIZE
+      break if final_palette_chunky_colors.length >= max_palette_size
     end
 
     # Convert final palette to hex strings for JSON response
     output_hex_colors = final_palette_chunky_colors.map do |color|
-      ChunkyPNG::Color.to_hex_string(color, false) # false for #RRGGBB
+      ChunkyPNG::Color.to_hex(color, false) # false for #RRGGBB
     end
 
     # Integrate with PaletteManager (using the new final hex colors)

--- a/spec/app_integration_spec.rb
+++ b/spec/app_integration_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Application Integration Workflow' do
 
     it "clears the session" do
       # Set some dummy session data by starting a workflow
-      post '/step1', image: Rack::Test::UploadedFile.new(File.expand_path('../fixtures/test_image.png', __FILE__), 'image/png', true)
+      post '/step1', image: Rack::Test::UploadedFile.new(File.expand_path('fixtures/test_image.png', __dir__), 'image/png', true)
       expect(current_session_id).not_to be_nil
       first_sid = current_session_id
 
@@ -60,7 +60,7 @@ RSpec.describe 'Application Integration Workflow' do
 
       # After session.clear, the next request that tries to establish a session will create a new one.
       # So, we make another request that would initiate a session to check if the ID is different.
-      post '/step1', image: Rack::Test::UploadedFile.new(File.expand_path('../fixtures/test_image.png', __FILE__), 'image/png', true)
+      post '/step1', image: Rack::Test::UploadedFile.new(File.expand_path('fixtures/test_image.png', __dir__), 'image/png', true)
       new_sid = current_session_id
       expect(new_sid).not_to be_nil
       expect(new_sid).not_to eq(first_sid)
@@ -180,7 +180,7 @@ RSpec.describe 'Application Integration Workflow' do
 
   describe 'POST /palette_upload' do
     # Use the test_image.png created in before(:all) as it's simple but guaranteed to exist
-    let(:image_path) { File.expand_path('../fixtures/test_image.png', __dir__) }
+    let(:image_path) { File.expand_path('fixtures/test_image.png', __dir__) }
     let(:uploaded_file) { Rack::Test::UploadedFile.new(image_path, 'image/png', true) } # binary mode true
 
     context 'when a valid image is uploaded' do
@@ -260,7 +260,7 @@ RSpec.describe 'Application Integration Workflow' do
 
     context 'when an invalid file type is uploaded' do
       let(:non_image_file_path) do
-        path = File.expand_path('../fixtures/not_an_image.txt', __dir__)
+        path = File.expand_path('fixtures/not_an_image.txt', __dir__)
         File.write(path, "This is not an image.")
         path
       end
@@ -287,7 +287,7 @@ RSpec.describe 'Application Integration Workflow' do
     end
 
     context 'when fixture_distinct_colors.png is uploaded' do
-      let(:distinct_colors_image_path) { File.expand_path('../fixtures/fixture_distinct_colors.png', __dir__) }
+      let(:distinct_colors_image_path) { File.expand_path('fixtures/fixture_distinct_colors.png', __dir__) }
       let(:uploaded_distinct_colors_file) { Rack::Test::UploadedFile.new(distinct_colors_image_path, 'image/png', true) }
 
       before do

--- a/spec/lib/impressionist_spec.rb
+++ b/spec/lib/impressionist_spec.rb
@@ -39,20 +39,20 @@ module Impressionist
 end
 
 RSpec.describe Impressionist do
-  let(:fixture_dir) { File.expand_path('../../fixtures', __FILE__) }
+  let(:fixture_dir) { File.expand_path('../fixtures', __dir__) }
   let(:input_path) { File.join(fixture_dir, 'test_image.png') }
   let(:output_dir) { File.expand_path('../../../tmp/test_output', __FILE__) }
   let(:output_path) { File.join(output_dir, 'output_impressionist.png') }
 
   before(:all) do
-    fixture_png_path = File.join(File.expand_path('../../fixtures', __FILE__), 'test_image.png')
+    fixture_png_path = File.join(File.expand_path('../fixtures', __dir__), 'test_image.png')
     unless File.exist?(fixture_png_path)
       FileUtils.mkdir_p(File.dirname(fixture_png_path))
       File.open(fixture_png_path, 'wb') do |f|
         f.write(Base64.decode64('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='))
       end
     end
-    sample_png_path = File.join(File.expand_path('../../fixtures', __FILE__), 'sample_image.png')
+    sample_png_path = File.join(File.expand_path('../fixtures', __dir__), 'sample_image.png')
     unless File.exist?(sample_png_path)
       FileUtils.mkdir_p(File.dirname(sample_png_path))
       img = ChunkyPNG::Image.new(5, 5, ChunkyPNG::Color::WHITE)
@@ -406,7 +406,7 @@ RSpec.describe Impressionist do
 
         expected_colors_chunky.each do |expected_color|
           found_match = extracted_palette.any? { |actual_color| rgb_distance(expected_color, actual_color) < color_similarity_threshold }
-          expect(found_match).to be true, "Expected to find a color similar to #{ChunkyPNG::Color.to_hex_string(expected_color)} in palette: #{extracted_palette.map{|c| ChunkyPNG::Color.to_hex_string(c)}.join(', ')}"
+          expect(found_match).to be true, "Expected to find a color similar to #{ChunkyPNG::Color.to_hex(expected_color)} in palette: #{extracted_palette.map{|c| ChunkyPNG::Color.to_hex(c)}.join(', ')}"
         end
       end
     end
@@ -478,14 +478,14 @@ RSpec.describe Impressionist do
         spot_blue_hex = '#3232dc' # rgb(50, 50, 220) -> quant(32) -> rgb(32, 32, 224)
 
         # Quantized expected spot colors
-        quantized_spot_red = hex_to_color(ChunkyPNG::Color.to_hex_string(ChunkyPNG::Color.rgb((220/32)*32, (50/32)*32, (50/32)*32), false))
-        quantized_spot_blue = hex_to_color(ChunkyPNG::Color.to_hex_string(ChunkyPNG::Color.rgb((50/32)*32, (50/32)*32, (220/32)*32), false))
+        quantized_spot_red = hex_to_color(ChunkyPNG::Color.to_hex(ChunkyPNG::Color.rgb((220/32)*32, (50/32)*32, (50/32)*32), false))
+        quantized_spot_blue = hex_to_color(ChunkyPNG::Color.to_hex(ChunkyPNG::Color.rgb((50/32)*32, (50/32)*32, (220/32)*32), false))
 
         found_spot_red = extracted_palette.any? { |actual_color| rgb_distance(quantized_spot_red, actual_color) < color_similarity_threshold }
         found_spot_blue = extracted_palette.any? { |actual_color| rgb_distance(quantized_spot_blue, actual_color) < color_similarity_threshold }
 
-        expect(found_spot_red).to be false, "Red spot color was found, but expected to be filtered by min_blob_size. Palette: #{extracted_palette.map{|c| ChunkyPNG::Color.to_hex_string(c)}.join(', ')}"
-        expect(found_spot_blue).to be false, "Blue spot color was found, but expected to be filtered by min_blob_size. Palette: #{extracted_palette.map{|c| ChunkyPNG::Color.to_hex_string(c)}.join(', ')}"
+        expect(found_spot_red).to be false, "Red spot color was found, but expected to be filtered by min_blob_size. Palette: #{extracted_palette.map{|c| ChunkyPNG::Color.to_hex(c)}.join(', ')}"
+        expect(found_spot_blue).to be false, "Blue spot color was found, but expected to be filtered by min_blob_size. Palette: #{extracted_palette.map{|c| ChunkyPNG::Color.to_hex(c)}.join(', ')}"
       end
     end
   end

--- a/spec/lib/palette_manager_spec.rb
+++ b/spec/lib/palette_manager_spec.rb
@@ -7,7 +7,7 @@ require_relative '../../lib/palette_manager'
 # or that internal image processing is mocked.
 
 RSpec.describe PaletteManager do
-  let(:fixture_dir) { File.expand_path('../../fixtures', __FILE__) }
+  let(:fixture_dir) { File.expand_path('../fixtures', __dir__) }
   let(:sample_palette_image_path) { File.join(fixture_dir, 'sample_palette.png') } # Assume this exists or will be created
   let(:empty_image_path) { File.join(fixture_dir, 'empty_image.png') } # Assume this exists
 


### PR DESCRIPTION
## Summary
- use `ChunkyPNG::Color.to_hex` rather than missing `to_hex_string`
- avoid constant redefinition warnings by using local variables
- fix broken fixture paths in integration tests
- update specs to use the correct hex helper

## Testing
- `bundle exec rspec` *(fails: 5 examples)*

------
https://chatgpt.com/codex/tasks/task_e_6842202ded68832198d69172616c7883