### PR TITLE
Fix hex output with new ChunkyPNG API

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -194,7 +194,7 @@ post '/palette_upload' do
 
     # Convert final palette to hex strings for JSON response
     output_hex_colors = final_palette_chunky_colors.map do |color|
-      ChunkyPNG::Color.to_hex_string(color, false) # false for #RRGGBB
+      ChunkyPNG::Color.to_hex(color, false) # false for #RRGGBB
     end
 
     # Integrate with PaletteManager (using the new final hex colors)


### PR DESCRIPTION
## Summary
- use `ChunkyPNG::Color.to_hex` when converting palette colors

## Testing
- `bundle exec rake test` *(fails: rbenv ruby 3.1.2 not installed)*
- `bundle exec rspec` *(fails: rbenv ruby 3.1.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68425f30d9f0832187392e49edefaa10